### PR TITLE
feat : #82 Integrate Mobile App Template into Monorepo via Mason Brick

### DIFF
--- a/internal/cmd/generate-app.ts
+++ b/internal/cmd/generate-app.ts
@@ -99,7 +99,7 @@ export default defineCommand({
         if (isCancel(appName)) { cancel('Operation cancelled.'); process.exit(0) }
 
         const appDirName = appName.toLowerCase().replace(/ /g, '-');
-        const appDir = join(process.cwd(), 'apps', appDirName);
+        const appDir = join(process.cwd(), 'apps', `mobile-${appDirName}`);
         if (!existsSync(appDir)) {
           mkdirSync(appDir, { recursive: true })
           _console.info(`Created folder: ${appDir}`)

--- a/internal/cmd/generate-app.ts
+++ b/internal/cmd/generate-app.ts
@@ -84,11 +84,11 @@ export default defineCommand({
           { value: 'react-ssr', label: 'React SSR' },
           { value: 'shared-ui', label: 'Shared UI' },
           { value: 'strapi', label: 'Strapi' },
-          { value: 'mobile', label: 'Mobile' },
+          { value: 'flutter', label: 'Flutter' },
         ],
       })
 
-      if (appType === 'mobile') {
+      if (appType === 'flutter') {
        
 
         const appName = await text({
@@ -99,7 +99,7 @@ export default defineCommand({
         if (isCancel(appName)) { cancel('Operation cancelled.'); process.exit(0) }
 
         const appDirName = appName.toLowerCase().replace(/ /g, '-');
-        const appDir = join(process.cwd(), 'apps', `mobile-${appDirName}`);
+        const appDir = join(process.cwd(), 'apps', `flutter-${appDirName}`);
         if (!existsSync(appDir)) {
           mkdirSync(appDir, { recursive: true })
           _console.info(`Created folder: ${appDir}`)
@@ -108,7 +108,7 @@ export default defineCommand({
         }
 
         const confirmAction = await confirm({
-          message: `Do you want to generate the mobile app in "${appDir}"?`,
+          message: `Do you want to generate the mobile flutter app in "${appDir}"?`,
           initialValue: true,
         })
         if (isCancel(confirmAction) || !confirmAction) {
@@ -216,8 +216,8 @@ export default defineCommand({
           },
         ])
 
-        s.stop('Mobile app generated!')
-        outro(`You're all set! Your new mobile app is ready in "apps/mobile"! 🚀`)
+        s.stop('Mobile Flutter app generated!')
+        outro(`You're all set! Your new mobile flutter app is ready in "${appDir}"! 🚀`)
         return
       }
 

--- a/internal/cmd/generate-app.ts
+++ b/internal/cmd/generate-app.ts
@@ -89,7 +89,17 @@ export default defineCommand({
       })
 
       if (appType === 'mobile') {
-        const appDir = join(process.cwd(), 'apps', 'mobile')
+       
+
+        const appName = await text({
+          message: 'What is the app\'s name?',
+          placeholder: 'default : ZOG Mobile Starter',
+          defaultValue: 'ZOG Mobile Starter',
+        })
+        if (isCancel(appName)) { cancel('Operation cancelled.'); process.exit(0) }
+
+        const appDirName = appName.toLowerCase().replace(/ /g, '-');
+        const appDir = join(process.cwd(), 'apps', appDirName);
         if (!existsSync(appDir)) {
           mkdirSync(appDir, { recursive: true })
           _console.info(`Created folder: ${appDir}`)
@@ -105,13 +115,6 @@ export default defineCommand({
           cancel('Operation cancelled.')
           process.exit(0)
         }
-
-        const appName = await text({
-          message: 'What is the app\'s name?',
-          placeholder: 'default : ZOG Mobile Starter',
-          defaultValue: 'ZOG Mobile Starter',
-        })
-        if (isCancel(appName)) { cancel('Operation cancelled.'); process.exit(0) }
 
         const packageName = await text({
           message: 'What is the app\'s package name?',

--- a/internal/cmd/generate-app.ts
+++ b/internal/cmd/generate-app.ts
@@ -1,5 +1,5 @@
 import { execSync } from 'node:child_process'
-import { existsSync } from 'node:fs'
+import { existsSync, mkdirSync, unlinkSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { intro, outro, spinner, tasks } from '@clack/prompts'
 import { cancel, confirm, isCancel, select, text } from '@clack/prompts'
@@ -84,8 +84,139 @@ export default defineCommand({
           { value: 'react-ssr', label: 'React SSR' },
           { value: 'shared-ui', label: 'Shared UI' },
           { value: 'strapi', label: 'Strapi' },
+          { value: 'mobile', label: 'Mobile' },
         ],
       })
+
+      if (appType === 'mobile') {
+        const appDir = join(process.cwd(), 'apps', 'mobile')
+        if (!existsSync(appDir)) {
+          mkdirSync(appDir, { recursive: true })
+          _console.info(`Created folder: ${appDir}`)
+        } else {
+          _console.info(`Folder already exists: ${appDir}`)
+        }
+
+        const confirmAction = await confirm({
+          message: `Do you want to generate the mobile app in "${appDir}"?`,
+          initialValue: true,
+        })
+        if (isCancel(confirmAction) || !confirmAction) {
+          cancel('Operation cancelled.')
+          process.exit(0)
+        }
+
+        const appName = await text({
+          message: 'What is the app\'s name?',
+          placeholder: 'default : ZOG Mobile Starter',
+          defaultValue: 'ZOG Mobile Starter',
+        })
+        if (isCancel(appName)) { cancel('Operation cancelled.'); process.exit(0) }
+
+        const packageName = await text({
+          message: 'What is the app\'s package name?',
+          placeholder: 'default : zog_starter',
+          defaultValue: 'zog_starter',
+        })
+        if (isCancel(packageName)) { cancel('Operation cancelled.'); process.exit(0) }
+
+        const devFirebaseProjectId = await text({
+          message: 'What is the development app\'s Firebase project ID?',
+          placeholder: 'default : zog-starter-dev',
+          defaultValue: 'zog-starter-dev',
+        })
+        if (isCancel(devFirebaseProjectId)) { cancel('Operation cancelled.'); process.exit(0) }
+
+        const stgFirebaseProjectId = await text({
+          message: 'What is the staging app\'s Firebase project ID?',
+          placeholder: 'default : zog-starter-stg',
+          defaultValue: 'zog-starter-stg',
+        })
+        if (isCancel(stgFirebaseProjectId)) { cancel('Operation cancelled.'); process.exit(0) }
+
+        const prodFirebaseProjectId = await text({
+          message: 'What is the production app\'s Firebase project ID?',
+          placeholder: 'default : zog-starter-prod',
+          defaultValue: 'zog-starter-prod',
+        })
+        if (isCancel(prodFirebaseProjectId)) { cancel('Operation cancelled.'); process.exit(0) }
+
+        const androidAppId = await text({
+          message: 'What is the Android App ID?',
+          placeholder: 'default : com.zog.mobile',
+          defaultValue: 'com.zog.mobile',
+        })
+        if (isCancel(androidAppId)) { cancel('Operation cancelled.'); process.exit(0) }
+
+        const iosBundleId = await text({
+          message: 'What is the iOS Bundle ID?',
+          placeholder: 'default : com.zog.mobile',
+          defaultValue: 'com.zog.mobile',
+        })
+        if (isCancel(iosBundleId)) { cancel('Operation cancelled.'); process.exit(0) }
+
+        const s = spinner()
+        s.start('Running mason commands...')
+
+        await tasks([
+          {
+            title: 'Initialize mason',
+            task: async () => {
+              const masonYaml = join(appDir, 'mason.yaml')
+              if (existsSync(masonYaml)) {
+                unlinkSync(masonYaml)
+              }
+              execSync('mason init', { cwd: appDir, stdio: 'inherit' })
+            },
+          },
+          {
+            title: 'Add app_scaffolding brick',
+            task: async () => {
+              execSync(
+                'mason add app_scaffolding --git-url https://github.com/zero-one-group/zog-mobile-bricks.git --git-path app_scaffolding',
+                { cwd: appDir, stdio: 'inherit' }
+              )
+            },
+          },
+          {
+            title: 'Run mason get',
+            task: async () => {
+              execSync('mason get', { cwd: appDir, stdio: 'inherit' })
+            },
+          },
+          {
+            title: 'Run mason make app_scaffolding',
+            task: async () => {
+              const config = {
+                appName,
+                packageName,
+                devFirebaseProjectId,
+                stgFirebaseProjectId,
+                prodFirebaseProjectId,
+                androidAppId,
+                iosBundleId,
+              }
+              const configPath = join(appDir, 'config.json')
+              writeFileSync(configPath, JSON.stringify(config, null, 2))
+
+              try {
+                execSync(
+                  `mason make app_scaffolding --on-conflict overwrite --config-path config.json`,
+                  { cwd: appDir, stdio: 'inherit' }
+                )
+              } finally {
+                if (existsSync(configPath)) {
+                  unlinkSync(configPath)
+                }
+              }
+            },
+          },
+        ])
+
+        s.stop('Mobile app generated!')
+        outro(`You're all set! Your new mobile app is ready in "apps/mobile"! 🚀`)
+        return
+      }
 
       if (isCancel(appType)) {
         cancel('Operation cancelled.')


### PR DESCRIPTION
## Description 📋

Add : 
- Add option mobile into command `pnpm -s cmd generate:app`
- Create a apps/mobile directory
- Call a series of commands that are commonly used when manually cloning a Mason Brick project.


https://github.com/user-attachments/assets/272bc323-b3f6-484d-8b0d-8dfbbd249ce0

Fixes [#82](https://github.com/zero-one-group/monorepo/issues/82)

## Note 
- There is  an error in the `mobile_brick` post generator after implement app_scaffolding, but the process add mobile project is actually already done. Will fix in repository of mobile brick itself

<img width="959" height="92" alt="Screenshot at Jul 18 15-38-55" src="https://github.com/user-attachments/assets/23d22c65-3ff8-43c1-99ca-016480aeccbf" />


## Type of change 🤔

Please tick any that are relevant to this PR and remove any that aren't.

- [ ] Bugfix (non breaking change which resolve an issue)
- [x] Feature (non breaking change which adds functionality)
- [ ] Breaking Change (a change which would cause existing functionality to not work as expected)
- [ ] Documentation (a change to documentation)

## Submission checklist ✅

- [x] I have performed a self review of my changes
- [x] I have updated the documentation where relevant
- [x] My changes are well written and all ci is passing
