### PR TITLE
fix(vpn): remove container dns pin that breaks pritunl public-ip dete…

### DIFF
--- a/templates/ansible/roles/vpn/README.md
+++ b/templates/ansible/roles/vpn/README.md
@@ -24,6 +24,17 @@ ansible-playbook -i inventory.ini initial-setup.yml --tags vpn
 
 ## 📝 Notes
 
+The compose file must **not** pin the container DNS to `127.0.0.1`: nothing
+listens there inside the container, so pritunl's public-IP detection fails and
+generated client profiles contain `remote None <port> <proto>`, which clients
+can never resolve (stuck on "Connecting"). Docker's embedded resolver
+(`127.0.0.11`) forwards to the host DNS automatically, and pritunl then
+auto-detects the public IP for the `remote` line in profiles.
+
+After first boot, in the web UI (Server → Settings) **remove the DNS server**
+(leave it empty) and **add the VPC CIDR prefix to the server routes** (e.g.
+`172.31.0.0/16`) so VPN clients can reach your VPC.
+
 On Ubuntu 26.04 the legacy iptables kernel modules are no longer loaded by default
 (the kernel defaults to nftables), which breaks Pritunl's NAT and filter rules.
 This role loads them on the target host and persists the list in

--- a/templates/ansible/roles/vpn/files/vpn.yml
+++ b/templates/ansible/roles/vpn/files/vpn.yml
@@ -7,8 +7,9 @@ services:
     network_mode: bridge
     sysctls:
       - net.ipv6.conf.all.disable_ipv6=0
-    dns:
-        - 127.0.0.1
+    # No explicit dns: — 127.0.0.1 breaks container DNS (nothing listens there),
+    # pritunl public-IP detection fails, and client profiles get "remote None".
+    # Docker's embedded resolver (127.0.0.11) forwards to the host DNS automatically.
     volumes:
         - './pritunl.conf:/etc/pritunl.conf'
         - './pritunl:/var/lib/pritunl'


### PR DESCRIPTION
## Description 📋
remove container dns pin that breaks pritunl public-ip detection

## Type of change 🤔

Please tick any that are relevant to this PR and remove any that aren't.

- [✅] Bugfix (non breaking change which resolve an issue)
- [ ] Feature (non breaking change which adds functionality)
- [ ] Breaking Change (a change which would cause existing functionality to not work as expected)
- [ ] Documentation (a change to documentation)

## Submission checklist ✅

- [✅] I have performed a self review of my changes
- [✅] I have updated the documentation where relevant
- [ ] My changes are well written and all ci is passing
