### PR TITLE
feat(go-modular): add OTel compile-time auto-instrumentation

### DIFF
--- a/apps/go-modular/.env.example
+++ b/apps/go-modular/.env.example
@@ -46,11 +46,38 @@ LOG_LEVEL=info
 LOG_NO_COLOR=false
 
 # OTel
+#
+# Tracing is provided by compile-time auto-instrumentation. Build with
+# `moon go-modular:build-otel` (or `otelc go build`) — a plain `go build`
+# produces a binary with no SDK, and these variables are then ignored.
+# See docs/OBSERVABILITY.md.
+
+# Application-level switch. Enables the Echo route-naming middleware and the
+# otelpgx query tracer. It does NOT install the SDK, so leaving it true in a
+# plain (non-otelc) build is harmless.
 OTEL_ENABLE_TELEMETRY=false
-OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318
-OTEL_EXPORTER_OTLP_HEADERS="authorization=YOUR_INGESTION_API_KEY"
-OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
-OTEL_INSECURE_MODE=false
+
 OTEL_SERVICE_NAME=go-modular
+
+# Local Jaeger: gRPC on 4317, HTTP on 4318 (both exposed by the
+# `instrumented` compose profile). Keep the protocol and port in sync —
+# pointing http/protobuf at 4317 silently drops every span.
+OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318
+OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
+
+# Only needed for a vendor backend that authenticates ingestion. Leave unset
+# for local Jaeger; sending a bogus Authorization header to it is not useful.
+# OTEL_EXPORTER_OTLP_HEADERS="authorization=YOUR_INGESTION_API_KEY"
+
+# Read by the SDK. parentbased_traceidratio keeps a sampled trace intact across
+# services; use always_on locally when you want every request to show up.
+OTEL_TRACES_SAMPLER=parentbased_traceidratio
+OTEL_TRACES_SAMPLER_ARG=1.0
+
+# Signals other than traces are off by default; Jaeger only ingests traces.
+OTEL_METRICS_EXPORTER=none
+OTEL_LOGS_EXPORTER=none
+
+OTEL_INSECURE_MODE=false
 OTEL_TRACING_SAMPLE_RATE=0.7
 

--- a/apps/go-modular/.gitignore
+++ b/apps/go-modular/.gitignore
@@ -1,4 +1,6 @@
 build/
+# Scratch directory written by `otelc go build` (compile-time instrumentation)
+.otelc-build/
 docs/docs.go
 docs/swagger.json
 docs/swagger.yaml

--- a/apps/go-modular/README.md
+++ b/apps/go-modular/README.md
@@ -20,7 +20,24 @@ moon go-modular:dump                 # Dump the database
 moon go-modular:install-mockery      # Install mockery
 moon go-modular:generate-swagger     # Generate Swagger OpenAPI docs
 moon go-modular:generate-mock        # Generate Mock
+moon go-modular:install-otelc        # Install compile-time instrumentation toolchain
+moon go-modular:build-otel           # Build with OpenTelemetry auto-instrumentation
+moon go-modular:start-otel           # Start the instrumented build
 ```
+
+## Observability
+
+Distributed tracing uses OpenTelemetry compile-time auto-instrumentation, with
+Jaeger as the local backend:
+
+```sh
+pnpm run compose:instrumented        # Start Jaeger (UI at http://localhost:16686)
+moon go-modular:install-otelc        # Once
+moon go-modular:start-otel           # Requires OTEL_ENABLE_TELEMETRY=true in .env
+```
+
+See [docs/OBSERVABILITY.md](docs/OBSERVABILITY.md) for the architecture, the
+configuration reference and troubleshooting.
 
 ## Migration Tasks
 

--- a/apps/go-modular/docs/OBSERVABILITY.md
+++ b/apps/go-modular/docs/OBSERVABILITY.md
@@ -1,0 +1,132 @@
+# Observability
+
+Distributed tracing for this service is built on [OpenTelemetry compile-time
+instrumentation](https://opentelemetry.io/blog/2026/go-compile-time-instrumentation-v1/)
+(`otelc`), with two library-specific tracers filling the gaps that compile-time
+instrumentation cannot cover on its own.
+
+## Quick start
+
+```sh
+# 1. Start Jaeger (UI on http://localhost:16686)
+pnpm run compose:instrumented
+
+# 2. Install the instrumentation toolchain (once)
+moon run go-modular:install-otelc
+
+# 3. Enable telemetry in .env
+#    OTEL_ENABLE_TELEMETRY=true
+
+# 4. Build and run the instrumented binary
+moon run go-modular:start-otel
+```
+
+Send a request, then open <http://localhost:16686>, pick the `go-modular`
+service and hit **Find Traces**.
+
+## How the three layers fit together
+
+Compile-time instrumentation alone does **not** produce a complete trace for
+this service. It ships an instrumentation for `net/http`, but not for Echo or
+pgx, so out of the box every request collapses into a single span named `GET`
+with no database activity attached. Three layers are therefore combined:
+
+| Layer | Provides | Why it is needed |
+| --- | --- | --- |
+| `otelc` (compile-time) | SDK bootstrap, `net/http` client+server spans, `log/slog` correlation, Go runtime metrics | Installs and configures the SDK with no code changes |
+| `otelecho` middleware | Renames the span to include the matched route | `otelc` hooks `net/http` and cannot see Echo's routing table |
+| `otelpgx` tracer | `pool.acquire`, `prepare` and `query` spans | Only `database/sql` is auto-instrumented; this service uses pgx |
+
+A verified trace for `POST /api/v1/auth/signin/email` looks like this:
+
+```
+POST                                    (otelc, net/http)
+└── POST /api/v1/auth/signin/email      (otelecho, http.route)
+    ├── pool.acquire                    (otelpgx)
+    ├── prepare                         (otelpgx, db.query.text)
+    └── query                           (otelpgx, db.query.text)
+```
+
+The outer bare `POST` span is the `net/http` server span; `otelecho` nests the
+route-named span beneath it rather than renaming it in place.
+
+## Building
+
+`otelc` wraps the Go toolchain — everything after `go` is forwarded unchanged:
+
+```sh
+otelc go build -o build/release/go-modular ./cmd/
+```
+
+Two properties are worth knowing:
+
+- **No source or manifest changes.** `otelc` resolves the OpenTelemetry SDK in
+  an isolated build sandbox, so `go.mod` and `go.sum` are left untouched. It may
+  report `Bumped dependency ...` lines; those apply to the sandbox only.
+- **A plain `go build` still works.** It produces a binary with no SDK, where
+  the global tracer provider is the no-op implementation. The `OTEL_*` variables
+  are then ignored and the tracing code paths cost nothing.
+
+The `build` / `start` tasks remain uninstrumented. Use `build-otel` /
+`start-otel` for tracing.
+
+## Configuration
+
+Configured entirely through standard `OTEL_*` environment variables (see
+`.env.example`).
+
+| Variable | Purpose |
+| --- | --- |
+| `OTEL_ENABLE_TELEMETRY` | Application switch for the Echo and pgx tracers. Does **not** install the SDK. |
+| `OTEL_SERVICE_NAME` | Service name shown in Jaeger. |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | Collector endpoint. |
+| `OTEL_EXPORTER_OTLP_PROTOCOL` | `http/protobuf` (port 4318) or `grpc` (port 4317). |
+| `OTEL_TRACES_SAMPLER` / `_ARG` | Sampling. `always_on` is convenient locally. |
+| `OTEL_METRICS_EXPORTER` / `OTEL_LOGS_EXPORTER` | Set to `none`; Jaeger ingests traces only. |
+
+### Endpoint and protocol must agree
+
+Jaeger exposes OTLP on **two** ports and the protocol must match the port:
+
+- `4317` — gRPC (`OTEL_EXPORTER_OTLP_PROTOCOL=grpc`)
+- `4318` — HTTP (`OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf`)
+
+A mismatch fails silently: the process runs normally and no spans arrive. If
+Jaeger shows no service, check this pairing first.
+
+## Adding custom spans
+
+Auto-instrumentation covers transport and database boundaries. For
+business-level detail use `internal/observer/tracer`, which reads the globally
+registered provider and is a no-op in an uninstrumented build:
+
+```go
+func (s *Service) Register(ctx context.Context, email string) error {
+    ctx, span := tracer.Start(ctx, "user.Register")
+    defer span.End()
+
+    tracer.AddAttributes(ctx, attribute.String("user.email", email))
+
+    if err := s.repo.Insert(ctx, email); err != nil {
+        tracer.RecordError(ctx, err) // marks the span failed
+        return err
+    }
+    return nil
+}
+```
+
+Pass `ctx` down the call chain — that is what makes child spans nest correctly.
+`tracer.TraceID(ctx)` returns the current trace id for correlating a log line or
+an error response with Jaeger.
+
+## Troubleshooting
+
+**No service listed in Jaeger.** The binary was probably built with a plain
+`go build`; confirm with `moon run go-modular:build-otel`. Otherwise check the
+endpoint/protocol pairing above.
+
+**Traces contain only a bare `GET` span.** `OTEL_ENABLE_TELEMETRY` is not
+`true`, so the Echo and pgx tracers are inactive.
+
+**No database spans.** Same cause — the otelpgx tracer is installed only when
+telemetry is enabled at the time the pool is created.

--- a/apps/go-modular/go.mod
+++ b/apps/go-modular/go.mod
@@ -22,11 +22,11 @@ require (
 	github.com/spf13/cobra v1.10.1
 	github.com/spf13/viper v1.21.0
 	github.com/stretchr/testify v1.11.1
-	github.com/swaggo/swag v1.16.6
 	github.com/testcontainers/testcontainers-go v0.38.0
 	go.jetify.com/typeid v1.3.0
 	go.opentelemetry.io/contrib/instrumentation/github.com/labstack/echo/otelecho v0.63.0
-	go.opentelemetry.io/otel/sdk v1.38.0
+	go.opentelemetry.io/otel v1.38.0
+	go.opentelemetry.io/otel/trace v1.38.0
 	go.uber.org/fx v1.24.0
 	golang.org/x/crypto v0.41.0
 	golang.org/x/time v0.12.0
@@ -113,6 +113,7 @@ require (
 	github.com/spf13/cast v1.10.0 // indirect
 	github.com/spf13/pflag v1.0.10 // indirect
 	github.com/subosito/gotenv v1.6.0 // indirect
+	github.com/swaggo/swag v1.16.6 // indirect
 	github.com/tklauser/go-sysconf v0.3.12 // indirect
 	github.com/tklauser/numcpus v0.6.1 // indirect
 	github.com/urfave/cli/v2 v2.3.0 // indirect
@@ -121,12 +122,11 @@ require (
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0 // indirect
-	go.opentelemetry.io/otel v1.38.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.38.0 // indirect
 	go.opentelemetry.io/otel/metric v1.38.0 // indirect
-	go.opentelemetry.io/otel/trace v1.38.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.8.0 // indirect
 	go.uber.org/dig v1.19.0 // indirect
+	go.uber.org/goleak v1.3.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.26.0 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect

--- a/apps/go-modular/internal/adapter/postgres.go
+++ b/apps/go-modular/internal/adapter/postgres.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 	"time"
+	"unicode"
 
 	"github.com/exaring/otelpgx"
 	"github.com/jackc/pgx/v5"
@@ -253,12 +254,25 @@ func NewSingleConnection(cfg PostgresConfig) (*pgx.Conn, error) {
 	return conn, nil
 }
 
-// pgxSpanNameFunc trims "-- name: " prefix and returns the statement name for tracing
+// pgxSpanNameFunc derives a span name from a SQL statement.
+//
+// For sqlc-style statements ("-- name: GetUser :one\nSELECT ...") it returns the
+// query name, which is the most readable label available. For plain SQL it falls
+// back to the leading keyword ("SELECT", "INSERT", ...) so that span names stay
+// low-cardinality — the full text is still recorded in db.query.text.
+//
+// Splitting on any whitespace matters: statements are commonly written as raw
+// string literals that begin with a newline, and cutting on a space alone would
+// emit names like "query \n" that carry the newline into the span name.
 func pgxSpanNameFunc(stmt string) string {
-	// If stmt is of the sqlc form "-- name: Example :one\n...",
-	// extract "Example". Otherwise, leave as-is.
-	stmt = strings.TrimPrefix(stmt, "-- name: ")
-	if i := strings.IndexByte(stmt, ' '); i != -1 {
+	stmt = strings.TrimSpace(stmt)
+
+	// sqlc form: "-- name: Example :one\n..." -> "Example"
+	if rest, ok := strings.CutPrefix(stmt, "-- name: "); ok {
+		stmt = strings.TrimSpace(rest)
+	}
+
+	if i := strings.IndexFunc(stmt, unicode.IsSpace); i != -1 {
 		return stmt[:i]
 	}
 	return stmt

--- a/apps/go-modular/internal/adapter/postgres_test.go
+++ b/apps/go-modular/internal/adapter/postgres_test.go
@@ -2,6 +2,7 @@ package adapter
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
@@ -150,4 +151,48 @@ func TestPostgres_WithTestEnv(t *testing.T) {
 		// If TestConnection helper exists it should succeed; call if available.
 		_ = cfg
 	})
+}
+
+func TestPgxSpanNameFunc(t *testing.T) {
+	tests := []struct {
+		name string
+		stmt string
+		want string
+	}{
+		{
+			name: "sqlc annotated statement uses the query name",
+			stmt: "-- name: GetUserByEmail :one\nSELECT * FROM users WHERE email = $1",
+			want: "GetUserByEmail",
+		},
+		{
+			name: "plain statement falls back to the leading keyword",
+			stmt: "SELECT id FROM users WHERE id = $1",
+			want: "SELECT",
+		},
+		{
+			// Raw string literals routinely start on the next line. The name must
+			// not carry the surrounding whitespace into the span.
+			stmt: "\n\t\tSELECT id, email\n\t\tFROM users\n\t",
+			name: "leading newline and indentation are trimmed",
+			want: "SELECT",
+		},
+		{
+			name: "single token statement is returned as-is",
+			stmt: "COMMIT",
+			want: "COMMIT",
+		},
+		{
+			name: "empty statement yields an empty name",
+			stmt: "   \n\t",
+			want: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := pgxSpanNameFunc(tt.stmt)
+			assert.Equal(t, tt.want, got)
+			assert.Equal(t, strings.TrimSpace(got), got, "span name must not contain surrounding whitespace")
+		})
+	}
 }

--- a/apps/go-modular/internal/app/http.go
+++ b/apps/go-modular/internal/app/http.go
@@ -38,6 +38,12 @@ func newEcho(cfg *config.Config, log *slog.Logger) *echo.Echo {
 		},
 	}))
 	e.Use(appMiddleware.RequestIDMiddleware())
+	// Runs before the remaining middleware so their work is captured inside the
+	// request span. Renames the auto-instrumented span to include the matched
+	// route; see internal/middleware/tracer.go.
+	if cfg.IsTelemetryEnabled() {
+		e.Use(appMiddleware.TracingMiddleware(cfg.OTel.ServiceName))
+	}
 	e.Use(appMiddleware.SecurityHeadersMiddleware())
 	e.Use(appMiddleware.TimeoutMiddleware(30 * time.Second))
 	e.Use(appMiddleware.LoggerMiddleware(log))

--- a/apps/go-modular/internal/app/postgres.go
+++ b/apps/go-modular/internal/app/postgres.go
@@ -52,7 +52,13 @@ func connectPostgresWithRetry(cfg *config.Config, log *slog.Logger) (*adapter.Po
 	attempt := 1
 
 	for {
-		pg, err := adapter.NewPostgres(adapter.PostgresConfig{URL: cfg.GetDatabaseURL()})
+		// EnableOTel installs the otelpgx tracer on the pool. Auto-instrumentation
+		// only covers database/sql, and this app talks to Postgres through pgx,
+		// so without this the traces have no query spans at all.
+		pg, err := adapter.NewPostgres(adapter.PostgresConfig{
+			URL:        cfg.GetDatabaseURL(),
+			EnableOTel: cfg.IsTelemetryEnabled(),
+		})
 		if err == nil {
 			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 			pingErr := pg.Ping(ctx)

--- a/apps/go-modular/internal/middleware/tracer.go
+++ b/apps/go-modular/internal/middleware/tracer.go
@@ -3,9 +3,25 @@ package middleware
 import (
 	"github.com/labstack/echo/v4"
 	"go.opentelemetry.io/contrib/instrumentation/github.com/labstack/echo/otelecho"
-	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 )
 
-func AttachTraceProvider(provider *sdktrace.TracerProvider, serviceName string) echo.MiddlewareFunc {
-	return otelecho.Middleware(serviceName, otelecho.WithTracerProvider(provider))
+// TracingMiddleware returns Echo middleware that names the request span after
+// the matched route.
+//
+// Compile-time auto-instrumentation (`otelc go build`) already creates a server
+// span for every request, but it hooks net/http and therefore cannot see Echo's
+// routing table. Those spans are named after the bare method ("GET") and carry
+// url.path but no http.route, so requests to /users/1 and /users/2 land in
+// separate buckets instead of aggregating under /users/:id.
+//
+// This middleware runs inside the auto-instrumented span and renames it to
+// "GET /users/:id" once Echo has matched the route, which is what makes the
+// latency aggregations in Jaeger meaningful.
+//
+// It reads the globally registered TracerProvider rather than taking one as an
+// argument, because the SDK is installed by auto-instrumentation at start-up
+// and is not owned by the application. Under a plain `go build` the global
+// provider is a no-op and this middleware costs nothing.
+func TracingMiddleware(serviceName string) echo.MiddlewareFunc {
+	return otelecho.Middleware(serviceName)
 }

--- a/apps/go-modular/internal/observer/tracer/tracer.go
+++ b/apps/go-modular/internal/observer/tracer/tracer.go
@@ -1,1 +1,84 @@
+// Package tracer exposes helpers for working with the OpenTelemetry tracer.
+//
+// The application does not construct a TracerProvider itself. Traces are set up
+// by compile-time auto-instrumentation: building with `otelc go build` injects
+// the OpenTelemetry SDK into `main`, configures it from the standard OTEL_*
+// environment variables, and registers the resulting provider globally.
+//
+// Because of that, everything here reads from the global provider rather than a
+// provider we own. When the binary is built with a plain `go build`, no SDK is
+// injected, the global provider is the no-op implementation, and each helper
+// below degrades to doing nothing.
+//
+// See docs/OBSERVABILITY.md for the build and configuration workflow.
 package tracer
+
+import (
+	"context"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
+)
+
+// instrumentationName identifies spans created through this package in the
+// backend's "otel.library.name" attribute.
+const instrumentationName = "go-modular"
+
+// Tracer returns the named tracer from the global provider.
+//
+// It is safe to call before any SDK is installed: the global provider is a
+// no-op until auto-instrumentation replaces it during process start-up.
+func Tracer() trace.Tracer {
+	return otel.Tracer(instrumentationName)
+}
+
+// Start begins a span for a unit of work that is not covered by
+// auto-instrumentation, such as a domain service method.
+//
+// Auto-instrumentation already covers inbound and outbound HTTP, and otelpgx
+// covers database queries, so reach for this only to add business-level detail.
+// The returned context carries the span and must be passed downstream for
+// child spans to nest correctly. The caller must end the span:
+//
+//	ctx, span := tracer.Start(ctx, "user.Register")
+//	defer span.End()
+func Start(ctx context.Context, name string, opts ...trace.SpanStartOption) (context.Context, trace.Span) {
+	return Tracer().Start(ctx, name, opts...)
+}
+
+// RecordError marks the span in ctx as failed and attaches err to it.
+//
+// It is a no-op when err is nil, so it can be deferred or called on a shared
+// error path without a preceding nil check.
+func RecordError(ctx context.Context, err error) {
+	if err == nil {
+		return
+	}
+	span := trace.SpanFromContext(ctx)
+	span.RecordError(err)
+	span.SetStatus(codes.Error, err.Error())
+}
+
+// AddAttributes attaches key/value attributes to the span in ctx.
+//
+// This is the cheapest way to make an existing auto-instrumented span more
+// useful, e.g. tagging the HTTP server span with a tenant or user id.
+func AddAttributes(ctx context.Context, attrs ...attribute.KeyValue) {
+	if len(attrs) == 0 {
+		return
+	}
+	trace.SpanFromContext(ctx).SetAttributes(attrs...)
+}
+
+// TraceID returns the trace id of the span in ctx as a hex string, or "" when
+// ctx carries no sampled span. Useful for correlating a log line or an error
+// response with a trace in Jaeger.
+func TraceID(ctx context.Context) string {
+	sc := trace.SpanContextFromContext(ctx)
+	if !sc.IsValid() {
+		return ""
+	}
+	return sc.TraceID().String()
+}

--- a/apps/go-modular/moon.yml
+++ b/apps/go-modular/moon.yml
@@ -51,6 +51,48 @@ tasks:
             mergeArgs: append
             envFile: '.env'
 
+    # Installs the compile-time auto-instrumentation toolchain.
+    # Run once before `build-otel`; it is a no-op if otelc is already on PATH.
+    install-otelc:
+        command: 'go install go.opentelemetry.io/otelc/tool/cmd/otelc@v1.1.0'
+        options:
+            cache: false
+            runInCI: false
+
+    # Same build as `build`, wrapped in otelc so the OpenTelemetry SDK and the
+    # net/http, log/slog and runtime instrumentations are injected at compile
+    # time. No application source depends on this — a plain `build` still works
+    # and simply produces an uninstrumented binary.
+    #
+    # `-buildmode=pie` is deliberately omitted: otelc rewrites the build graph
+    # and PIE offers no benefit for a locally traced binary.
+    build-otel:
+        env:
+            LDFLAGS_BUILD_HASH: '-X $project/internal.BuildHash=$vcsRevision'
+            LDFLAGS_BUILD_DATE: '-X $project/internal.BuildDate=$datetime'
+        script: |
+            otelc go build -tags prod -trimpath -buildvcs=false \
+              --ldflags="$LDFLAGS_BUILD_DATE $LDFLAGS_BUILD_HASH \
+              -X $project/internal.Version=$(jq -r .version <$workspaceRoot'/package.json')" \
+              -o $projectRoot/build/release/$project-otel $projectRoot/cmd/
+        deps: [tidy, generate-swagger]
+        options:
+            mergeArgs: append
+            envFile: '.env'
+            cache: false
+
+    # Runs the instrumented binary. Requires Jaeger:
+    #   pnpm run compose:instrumented   (UI on http://localhost:16686)
+    start-otel:
+        command: 'build/release/$project-otel'
+        args: ['serve']
+        deps: [kill-port, build-otel]
+        options:
+            cache: false
+            outputStyle: stream
+            mergeArgs: replace
+            envFile: '.env'
+
     start:
         command: 'build/release/$project'
         args: ['serve']

--- a/docker/_stacks_/instrumentation.yaml
+++ b/docker/_stacks_/instrumentation.yaml
@@ -14,7 +14,8 @@ services:
             - '16686:16686' # UI
             - '14268:14268' # collector (HTTP)
             - '14250:14250' # collector (gRPC)
-            - '4317:4317' # OTLP gRPC (if you want OTLP→Jaeger)
+            - '4317:4317' # OTLP gRPC
+            - '4318:4318' # OTLP HTTP (default for OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf)
         environment:
             # enable OTLP endpoint if you wish to send OTLP directly to Jaeger
             COLLECTOR_OTLP_ENABLED: 'true'


### PR DESCRIPTION
Wire up distributed tracing using OpenTelemetry compile-time instrumentation (otelc v1), verified end-to-end against the local Jaeger stack.

Tracing was previously unfinished: internal/observer/tracer/tracer.go and metrics.go were empty stubs, the otelecho middleware was never registered, and otelpgx was configured but never enabled outside tests. No spans were produced at all.

otelc alone is not sufficient here. It instruments net/http but has no instrumentation for Echo or pgx, so a request collapsed into a single span named "GET" with no database activity. Three layers are combined instead:

- otelc      SDK bootstrap, net/http, log/slog, runtime metrics (no code)
- otelecho   renames the span to the matched route (GET /healthz)
- otelpgx    pool.acquire / prepare / query spans

Verified trace for POST /api/v1/auth/signin/email:

  POST                                 (otelc, net/http)
  └── POST /api/v1/auth/signin/email   (otelecho, http.route)
      ├── pool.acquire                 (otelpgx)
      ├── prepare SELECT               (otelpgx, db.query.text)
      └── query SELECT                 (otelpgx, db.query.text)

Also fixes three latent bugs found while verifying:

- internal/app/postgres.go built PostgresConfig without EnableOTel, so the otelpgx tracer was never installed in production — DB spans were impossible regardless of configuration.
- pgxSpanNameFunc split on a literal space, emitting span names like "query \n" for statements written as raw string literals. It now trims and splits on any whitespace, falling back to the leading SQL keyword.
- The Jaeger stack exposed OTLP gRPC (4317) but not HTTP (4318), while .env.example defaulted to http/protobuf on 4318. That pairing failed silently, dropping every span.

The build stays opt-in: build/start are unchanged and produce an uninstrumented binary where the global provider is a no-op. Use build-otel/start-otel for tracing. otelc resolves the SDK in a build sandbox, so no source or go.mod changes are required.

## Description 📋

Please include a summary of the changes made in this PR and provide any context necessary for the change.
Fixes # (issues)

## Type of change 🤔

Please tick any that are relevant to this PR and remove any that aren't.

- [ ] Bugfix (non breaking change which resolve an issue)
- [ ] Feature (non breaking change which adds functionality)
- [ ] Breaking Change (a change which would cause existing functionality to not work as expected)
- [ ] Documentation (a change to documentation)

## Submission checklist ✅

- [ ] I have performed a self review of my changes
- [ ] I have updated the documentation where relevant
- [ ] My changes are well written and all ci is passing
