### PR TITLE
fix(shared-ui): type ToggleGroup props so single/multiple usage typechecks

### DIFF
--- a/packages/shared-ui/src/components/toggle-group/toggle-group.tsx
+++ b/packages/shared-ui/src/components/toggle-group/toggle-group.tsx
@@ -10,13 +10,47 @@ const ToggleGroupContext = React.createContext<ToggleVariants>({
   variant: 'default',
 })
 
-type ToggleGroupProps = React.ComponentPropsWithoutRef<'div'> & ToggleVariants
+/**
+ * Radix ToggleGroup props, redeclared locally instead of derived via
+ * `React.ComponentPropsWithoutRef<typeof ToggleGroupPrimitive.Root>`.
+ *
+ * Deriving them triggers TS2742 when emitting declarations: the inferred type
+ * references `@types/react` hoisted under `@radix-ui/*` (React 18), which is not
+ * portable from this package. Keep this union in sync with
+ * `ToggleGroupSingleProps` / `ToggleGroupMultipleProps` from
+ * `@radix-ui/react-toggle-group`.
+ */
+type ToggleGroupValueProps =
+  | {
+      type: 'single'
+      value?: string
+      defaultValue?: string
+      onValueChange?: (value: string) => void
+    }
+  | {
+      type: 'multiple'
+      value?: string[]
+      defaultValue?: string[]
+      onValueChange?: (value: string[]) => void
+    }
+
+type ToggleGroupProps = Omit<
+  React.ComponentPropsWithoutRef<'div'>,
+  'defaultValue' | 'dir'
+> &
+  ToggleGroupValueProps &
+  ToggleVariants & {
+    disabled?: boolean
+    rovingFocus?: boolean
+    loop?: boolean
+    orientation?: 'horizontal' | 'vertical'
+    dir?: 'ltr' | 'rtl'
+  }
 
 const ToggleGroup = React.forwardRef<HTMLDivElement, ToggleGroupProps>(
   ({ className, variant, size, children, ...props }, ref) => {
     const Root = ToggleGroupPrimitive.Root
     return (
-      // @ts-expect-error - hoisted Radix types resolve children with React 18 ReactNode (bigint not assignable)
       <Root ref={ref} className={toggleGroupStyles({ className })} {...props}>
         <ToggleGroupContext.Provider value={{ variant, size }}>
           {children}
@@ -26,7 +60,10 @@ const ToggleGroup = React.forwardRef<HTMLDivElement, ToggleGroupProps>(
   }
 )
 
-type ToggleGroupItemProps = React.ComponentPropsWithoutRef<'button'> & ToggleVariants
+type ToggleGroupItemProps = React.ComponentPropsWithoutRef<'button'> &
+  ToggleVariants & {
+    value: string
+  }
 
 const ToggleGroupItem = React.forwardRef<HTMLButtonElement, ToggleGroupItemProps>(
   ({ className, children, variant, size, ...props }, ref) => {
@@ -51,3 +88,4 @@ ToggleGroup.displayName = ToggleGroupPrimitive.Root.displayName
 ToggleGroupItem.displayName = ToggleGroupPrimitive.Item.displayName
 
 export { ToggleGroup, ToggleGroupItem }
+export type { ToggleGroupItemProps, ToggleGroupProps }

--- a/templates/shared-ui/src/components/toggle-group/toggle-group.raw.tsx
+++ b/templates/shared-ui/src/components/toggle-group/toggle-group.raw.tsx
@@ -10,13 +10,47 @@ const ToggleGroupContext = React.createContext<ToggleVariants>({
   variant: 'default',
 })
 
-type ToggleGroupProps = React.ComponentPropsWithoutRef<'div'> & ToggleVariants
+/**
+ * Radix ToggleGroup props, redeclared locally instead of derived via
+ * `React.ComponentPropsWithoutRef<typeof ToggleGroupPrimitive.Root>`.
+ *
+ * Deriving them triggers TS2742 when emitting declarations: the inferred type
+ * references `@types/react` hoisted under `@radix-ui/*` (React 18), which is not
+ * portable from this package. Keep this union in sync with
+ * `ToggleGroupSingleProps` / `ToggleGroupMultipleProps` from
+ * `@radix-ui/react-toggle-group`.
+ */
+type ToggleGroupValueProps =
+  | {
+      type: 'single'
+      value?: string
+      defaultValue?: string
+      onValueChange?: (value: string) => void
+    }
+  | {
+      type: 'multiple'
+      value?: string[]
+      defaultValue?: string[]
+      onValueChange?: (value: string[]) => void
+    }
+
+type ToggleGroupProps = Omit<
+  React.ComponentPropsWithoutRef<'div'>,
+  'defaultValue' | 'dir'
+> &
+  ToggleGroupValueProps &
+  ToggleVariants & {
+    disabled?: boolean
+    rovingFocus?: boolean
+    loop?: boolean
+    orientation?: 'horizontal' | 'vertical'
+    dir?: 'ltr' | 'rtl'
+  }
 
 const ToggleGroup = React.forwardRef<HTMLDivElement, ToggleGroupProps>(
   ({ className, variant, size, children, ...props }, ref) => {
     const Root = ToggleGroupPrimitive.Root
     return (
-      // @ts-expect-error - hoisted Radix types resolve children with React 18 ReactNode (bigint not assignable)
       <Root ref={ref} className={toggleGroupStyles({ className })} {...props}>
         <ToggleGroupContext.Provider value={{ variant, size }}>
           {children}
@@ -26,7 +60,10 @@ const ToggleGroup = React.forwardRef<HTMLDivElement, ToggleGroupProps>(
   }
 )
 
-type ToggleGroupItemProps = React.ComponentPropsWithoutRef<'button'> & ToggleVariants
+type ToggleGroupItemProps = React.ComponentPropsWithoutRef<'button'> &
+  ToggleVariants & {
+    value: string
+  }
 
 const ToggleGroupItem = React.forwardRef<HTMLButtonElement, ToggleGroupItemProps>(
   ({ className, children, variant, size, ...props }, ref) => {
@@ -51,3 +88,4 @@ ToggleGroup.displayName = ToggleGroupPrimitive.Root.displayName
 ToggleGroupItem.displayName = ToggleGroupPrimitive.Item.displayName
 
 export { ToggleGroup, ToggleGroupItem }
+export type { ToggleGroupItemProps, ToggleGroupProps }


### PR DESCRIPTION
## Description 📋

`ToggleGroupProps` was just `ComponentPropsWithoutRef<'div'> & ToggleVariants`, so `<ToggleGroup type="single">` (and `value` / `defaultValue` / `onValueChange`) failed to typecheck — `shared-ui:typecheck` was red on the package's own stories.

This PR:
- Declares `ToggleGroupValueProps` as a `type: 'single' | 'multiple'` discriminated union with matching `value` / `defaultValue` / `onValueChange`, plus `disabled` / `rovingFocus` / `loop` / `orientation` / `dir`.
- Requires `value: string` on `ToggleGroupItemProps`; exports both prop types.
- Drops the `@ts-expect-error` on `Root` (children now flow through the React‑19‑typed context `Provider`, so TS reported it as unused) and keeps the one on `Item`'s `{children}`, where TS actually reports the React 18 `ReactNode` mismatch.
- Regenerates the template snapshot with `bash builder/shared-ui.sh` (only `templates/shared-ui/.../toggle-group.raw.tsx` changed).

### Why the props are redeclared instead of `typeof ToggleGroupPrimitive.Root`

Deriving them via `React.ComponentPropsWithoutRef<typeof ToggleGroupPrimitive.Root>` makes declaration emit hit **TS2742**: the inferred type references the React 18 `@types/react` hoisted under `@radix-ui/*`, which is not portable from this package. Please don't "simplify" it back — the constraint is documented in a comment in the file. Removing the nested React 18 types via a `pnpm-workspace.yaml` override is a separate, riskier change.

Verified: `moon run shared-ui:lint shared-ui:typecheck shared-ui:build` all pass; emitted `dist/.../toggle-group.d.ts` contains no `node_modules` path.

## Type of change 🤔

- [x] Bugfix (non breaking change which resolve an issue)

## Submission checklist ✅

- [x] I have performed a self review of my changes
- [x] I have updated the documentation where relevant
- [x] My changes are well written and all ci is passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)