### PR TITLE
docs: warn that moon caches remote templates

### DIFF
--- a/docsite/content/create-new-project.md
+++ b/docsite/content/create-new-project.md
@@ -47,6 +47,12 @@ moon generate react-app
 
 Follow the interactive prompts to configure your new application, such as setting the project name and description.
 
+> [!WARNING]
+> moon caches downloaded templates in `~/.moon/templates/archive/` and never
+> re-downloads them. If you have generated from a template before, delete that
+> directory first so you get the current version. See
+> [Troubleshooting]({{< ref "troubleshooting.md" >}}) for details.
+
 ## 3. Configure Your Application
 
 After generation, you may need to perform some initial configuration:

--- a/docsite/content/troubleshooting.md
+++ b/docsite/content/troubleshooting.md
@@ -3,4 +3,43 @@ title: Troubleshooting
 slug: "troubleshooting"
 ---
 
-TODO
+## `moon generate` scaffolds an outdated template
+
+**Symptom:** `moon generate <template>` produces files that don't match what's
+currently in `templates/` on `main` (for example an older routing stack, or a
+component fix you know has already landed upstream).
+
+**Cause:** moon downloads remote template archives once and caches them. The
+templates listed in `.moon/workspace.yml` are stored under:
+
+```text
+~/.moon/templates/archive/oss.zero-one-group.com/<template>/
+```
+
+Each directory contains an `.installed-at` stamp. As long as that directory
+exists, moon reuses it and **does not re-download** the archive, even if the
+remote zip has been republished since.
+
+**Fix:** delete the cached archive before generating:
+
+```bash
+# one template
+rm -rf ~/.moon/templates/archive/oss.zero-one-group.com/<template>
+
+# or everything
+rm -rf ~/.moon/templates/archive
+
+moon generate <template>
+```
+
+To check whether your cache is stale without deleting it, compare the
+`.installed-at` stamp against the `last_updated` field of the published
+manifest:
+
+```bash
+curl -s https://oss.zero-one-group.com/monorepo/templates.json | head -3
+cat ~/.moon/templates/archive/oss.zero-one-group.com/<template>/.installed-at
+```
+
+If `last_updated` is newer than your stamp, clear the cache and re-run
+`moon generate`.


### PR DESCRIPTION
## Description 📋

`moon generate` downloads the remote template archives listed in `.moon/workspace.yml` once and caches them under `~/.moon/templates/archive/oss.zero-one-group.com/<template>/` (with an `.installed-at` stamp). It never re-downloads, so a machine that generated from a template months ago silently keeps scaffolding the old snapshot — e.g. getting React Router 7 when the current `react-app` template ships TanStack Router. This cost us a day on a downstream project.

This PR:
- Replaces the `TODO` in `docsite/content/troubleshooting.md` with a section covering the cache location, how to clear it, and how to compare the stamp against `last_updated` in `https://oss.zero-one-group.com/monorepo/templates.json`.
- Adds a `> [!WARNING]` callout under the `moon generate` example in `create-new-project.md` linking to it.

## Type of change 🤔

- [x] Documentation (a change to documentation)

## Submission checklist ✅

- [x] I have performed a self review of my changes
- [x] I have updated the documentation where relevant
- [x] My changes are well written and all ci is passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)