### PR TITLE
docs: test-first workflow, coverage ratchet, definition of done; real gitlab-cicd test jobs

### DIFF
--- a/docsite/content/contribution-guidelines.md
+++ b/docsite/content/contribution-guidelines.md
@@ -160,7 +160,7 @@ To ensure your contributions can be reviewed and merged efficiently, please foll
 *   **Create an Issue:** We encourage you to first create an issue describing the feature or bug you plan to work on. You can optionally tag the relevant maintainer(s) in the issue.
 *   **Branch Naming:** Use descriptive branch names following a convention (e.g., `feat/new-feature-name`, `fix/bug-description`, `docs/update-readme`).
 *   **Commit Messages:** Follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) for clear and concise commit messages. This helps with automated changelog generation and understanding the history.
-*   **Tests:** Ensure your changes are covered by appropriate tests (unit, integration, E2E). New features should have tests, and bug fixes should include a test that reproduces the bug.
+*   **Tests:** Work test-first — see [Testing]({{< ref "moonrepo-testing.md" >}}) for the loop, which test to write first per layer, and the coverage ratchet. New features need tests; bug fixes include the test that reproduces the bug. Before pushing changes to `moon.yml` tasks or CI files, reproduce a clean checkout locally (`MOON_CACHE=off moon run :lint :typecheck :build`, then `git clean -fdX && pnpm install` and the coverage tasks) — inferred tasks and generated inputs behave differently without a warm cache.
 *   **Documentation:** Update relevant documentation for any new features, significant changes, or breaking changes.
 *   **Review:** All pull requests require at least one approval from a designated reviewer before merging.
 

--- a/docsite/content/moonrepo-testing.md
+++ b/docsite/content/moonrepo-testing.md
@@ -1,52 +1,140 @@
 ---
-title: Moonrepo Testing
+title: Testing
 slug: "moonrepo-testing"
 ---
 
-## Template Golang
+How projects generated from these templates are tested: the test-first loop, which test to
+write first for each layer, how fixtures are handled, and how the coverage floors are raised
+over time. The templates ship the harnesses; this page is the workflow that goes with them.
+
+## The loop
+
+Every feature, fix or refactor is done test-first. Reviewers can tell when the tests were
+written after the code, and the coverage gate will tell them when they were not written at all.
+
+1. **Write the failing test first** — the smallest test that expresses the behaviour asked
+   for, named after the behaviour (`TestCheckout_RejectsUnavailableItem`,
+   `it('shows the confirmation once the order is placed')`), not the function. Run it. It must
+   fail for the right reason: an assertion, not a compile error you then "fix" by stubbing.
+2. **Make it pass with the least code** — no speculative branches, no config for cases the
+   test does not cover.
+3. **Refactor with the test green** — extract, rename, dedupe. Run the whole package/app
+   suite, not just the new test.
+4. **Repeat per behaviour.** One assertion cluster per test; a new edge case is a new test,
+   not an extra `if` in an existing one.
+5. Before opening the PR: `moon run :lint :typecheck :build`, the project's coverage task,
+   and the definition-of-done checklist below.
+
+Never delete or weaken a test to get green. If a test is wrong, say so explicitly and fix the
+test in its own commit.
+
+## Which test to write first (Go, `go-modular`)
+
+| You are writing…            | Start with                                                                                                                                                                   | Harness                                  |
+| --------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------- |
+| Domain rules (state machines, pricing, validation) | Pure table-driven unit test in `modules/<x>/domain`, every input pair enumerated                                                                                      | `testing` + testify, no DB               |
+| A service                   | Unit test with a fake or mocked repository (`moon run go-modular:generate-mock`) covering success, each error branch, and idempotency                                        | testify + mockery                        |
+| A repository                | Integration test against real Postgres/Redis via `pkg/testutils.NewTestEnv` + `RunAppMigrations`                                                                              | testcontainers                           |
+| A handler / route           | `httptest` through the real Echo router with a fake service: status code, error envelope, auth required                                                                       | Echo `httptest`                          |
+| Module wiring               | An `fx_test.go` next to `fx.go`: config validation, the route table, which routes sit behind the JWT guard (see `modules/auth/fx_test.go`)                                    | Echo `httptest`                          |
+| A webhook receiver          | Implement `pkg/testutils/webhook.Receiver`; the first test is `AssertIdempotent` + `AssertLateEventIgnored` + `AssertRejectsBadSignature` over a **recorded** fixture in `testdata/webhooks/<provider>/` | replay harness              |
+| A third-party client        | Contract test behind `//go:build contract` using `pkg/testutils/contract`; record once with `CONTRACT_RECORD=1` against the provider's test account, replay offline after       | contract recorder                        |
+| A migration                 | Apply on a fresh DB in a test (`RunAppMigrations`), assert the table/constraint exists, then write the repository test that uses it                                            | testcontainers                           |
+| The app as a whole          | Extend `internal/app/app_integration_test.go` — real Postgres, the fx graph exactly as `New()` builds it, one request per new module                                          | testcontainers + fxtest                  |
+
+## Which test to write first (React, `react-app`)
+
+| You are writing…                                   | Start with                                                                                                                                                       |
+| -------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| State/derivation logic (totals, status → copy)     | Pure unit test of the function or hook in `tests/`, before any JSX                                                                                              |
+| A component with behaviour (form, dialog, toggle)  | Testing Library test: render, act as the user (`userEvent`), assert on what the user sees — never on implementation details or class names                        |
+| A route                                            | `renderAt('/path')` from `tests/helpers.tsx` (the real router): loader/action outcomes, error and empty states, the redirect when unauthenticated                |
+| An API call                                        | Mock at the network boundary (`msw` or `vi.fn` on the client); assert the request shape and both success and error rendering                                     |
+| A user journey                                     | One Playwright spec per journey in `tests-e2e/`; extend it rather than adding a second file for the same journey                                                |
+| A `shared-ui` primitive                            | A Storybook story per variant is the test; add interaction tests only for behaviour Radix does not already guarantee                                            |
+
+Do not test template filler (`-welcome.tsx`), generated files (`routeTree.gen.ts`) or styling
+tokens — they are excluded from the coverage denominator for that reason.
+
+## Fixtures and test data
+
+- Third-party payloads are **recorded, never invented**. A hand-written provider payload
+  proves nothing about the provider. See `testdata/webhooks/README.md` and
+  `testdata/contract/README.md` in `go-modular`.
+- Seeders (`database/seeders`) are the only source of "realistic" local data; add a factory
+  there rather than inline SQL in tests.
+- Redact names, phone numbers and emails in any captured payload before committing.
+
+## Coverage: report, then ratchet
+
+Both templates measure coverage against an honest denominator (every source file, not only
+the ones a test happened to import) and ship with **floors at zero** — a template cannot know
+your project's baseline.
+
+- `moon run go-modular:coverage` — `scripts/coverage-gate.sh` prints three tiers: overall,
+  `modules/...`, and the packages named in `COVERAGE_CRITICAL_PACKAGES` (payments,
+  webhooks — whatever must never regress). Floors: `COVERAGE_MIN`, `COVERAGE_MIN_MODULES`,
+  `COVERAGE_MIN_CRITICAL` in `moon.yml`.
+- `moon run react-app:test-coverage` — vitest with `coverage.include: ['app/**']`; floors
+  go in `coverage.thresholds` in `vitest.config.ts`.
+
+**The ratchet rule:** once you have a baseline, set each floor to *measured − 5* and only ever
+raise it. Record the history next to the value (`YYYY-MM-DD what landed: measured → floor`) so
+the trend is visible. Lowering a floor is a decision that belongs in the PR description, not
+a quiet edit.
+
+## Definition of done
+
+The `gitlab-cicd` template ships a merge-request template with this checklist
+(`.gitlab/merge_request_templates/Default.md`). For GitHub, put the same list in
+`.github/pull_request_template.md`.
+
+- `moon run :lint :typecheck :build` passes locally.
+- Tests added or updated at the unit layer for the logic in the change.
+- Anything touching persistence has an integration test against the real store (testcontainers).
+- Webhook receivers pass the replay harness (idempotent · late-event-ignored ·
+  bad-signature-rejected) on **recorded** fixtures.
+- Migrations are additive-first and apply cleanly from scratch (`migrate:reset --up`).
+- `.env.example` regenerated if config changed.
+- The coverage task passes; if a floor was raised, the history line was added.
+
+## CI
+
+`templates/gitlab-cicd/test/all.yml` runs exactly the local gates so CI and `moon run …` agree:
+`lint-typecheck-build` (only affected projects, unless a workspace-level file changed), a
+`test-api` job with Docker-in-Docker for testcontainers and the gate's `overall` line as the
+job coverage, and a `.test-frontend` job template per SPA that publishes the JUnit report.
+
+Before pushing a CI change, reproduce the clean-checkout conditions locally:
 
 ```sh
-moon go-clean:build
-moon go-clean:start
-moon go-clean:docker-build
-moon go-clean:docker-shell
-moon go-clean:docker-run
+MOON_CACHE=off moon run :lint :typecheck :build   # no cached task outputs
+git clean -fdX                                    # drop every ignored file (generated code, node_modules, build/)
+pnpm install && moon run go-modular:coverage react-app:test-coverage
 ```
 
-## Template Next.js
+Two moon behaviours bite here: tasks inferred from `package.json` have no declared outputs,
+so moon can report them as cached with nothing on disk; and embedded/generated inputs
+(`docs/swagger.json`, `routeTree.gen.ts`) must be produced by a task the test task depends on.
+The templates declare both explicitly — keep it that way when adding tasks.
+
+## Template smoke tests
+
+Building and running each template end to end after changing it:
 
 ```sh
-moon nextjs-app:build
-moon nextjs-app:start
-moon nextjs-app:docker-build
-moon nextjs-app:docker-shell
-moon nextjs-app:docker-run
+# go-modular / go-clean
+moon go-modular:build && moon go-modular:start
+moon go-modular:docker-build && moon go-modular:docker-run
+
+# react-app / nextjs-app / strapi-cms
+moon react-app:build && moon react-app:start
+moon react-app:docker-build && moon react-app:docker-run
+
+# shared-ui
+moon shared-ui:build && moon shared-ui:storybook-build
 ```
 
-## Template React SPA
-
-```sh
-moon react-app:build
-moon react-app:start
-moon react-app:docker-build
-moon react-app:docker-shell
-moon react-app:docker-run
-```
-
-## Template Strapi
-
-```sh
-moon strapi-cms:build
-moon strapi-cms:start
-moon strapi-cms:docker-build
-moon strapi-cms:docker-shell
-moon strapi-cms:docker-run
-```
-
-## Template Shared UI
-
-```sh
-moon shared-ui:build
-moon shared-ui:storybook
-moon shared-ui:storybook-build
-```
+The acceptance test for a template change is to generate a throwaway project from the modified
+template and run `moon run :lint :typecheck :build` plus its coverage task there — remember that
+moon caches downloaded templates (see [Troubleshooting]({{< ref "troubleshooting.md" >}})).

--- a/templates/gitlab-cicd/.gitlab/merge_request_templates/Default.md
+++ b/templates/gitlab-cicd/.gitlab/merge_request_templates/Default.md
@@ -1,0 +1,34 @@
+## What & why
+
+<!-- One paragraph. Link the issue or decision record this depends on, if any. -->
+
+## Definition of done
+
+Tick what applies; explain anything unticked. Reviewers: do not approve a change to persistence,
+queues or integrations with unticked boxes.
+
+**Everyone**
+
+- [ ] `moon run :lint :typecheck :build` passes locally
+- [ ] Tests added or updated at the unit layer for the logic in this MR
+- [ ] The project's coverage task passes; if a floor was raised, the history line was added
+- [ ] Migrations (if any) are additive-first and apply cleanly from scratch (`migrate:reset --up`)
+- [ ] `.env.example` regenerated if config changed
+
+**If this touches persistence, a queue or an integration**
+
+- [ ] Integration test against the real store (testcontainers), not a mock
+- [ ] Webhook receivers pass the replay harness: idempotent · late-event-ignored ·
+      bad-signature-rejected, using **recorded** fixtures under `testdata/webhooks`
+- [ ] Correlation ID is on every new log line, span and audit row
+- [ ] Amounts / statuses from a third party are looked up against our own records, never trusted
+      from the payload
+
+**If this touches a third-party API contract**
+
+- [ ] Contract fixtures re-recorded from the provider's test account (`CONTRACT_RECORD=1`) and the
+      diff read
+
+## How to verify
+
+<!-- Commands, URLs, fixtures a reviewer can use. -->

--- a/templates/gitlab-cicd/test/all.yml
+++ b/templates/gitlab-cicd/test/all.yml
@@ -1,10 +1,134 @@
-test:
+# Test stage: runs exactly the gates that live in the repo, so CI and a local `moon run …` agree.
+#   - moon run :lint :typecheck :build         → oxlint / tsc / go build (+ swagger)
+#   - moon run <api>:coverage                  → go test (testcontainers) + scripts/coverage-gate.sh
+#   - moon run <spa>:test-coverage             → vitest + coverage.thresholds in vitest.config.ts
+# Any gate below its floor exits 1 and fails the job.
+#
+# Replace CHANGEME_API_APP / CHANGEME_WEB_APP with your project ids (apps/<id>), or delete the
+# jobs you do not need.
+
+variables:
+  GIT_DEPTH: "0" # full history: moon diffs against CI_MERGE_REQUEST_DIFF_BASE_SHA, which a shallow clone may not contain
+  # Workspace-level files that invalidate every project. When one of these changes the jobs run
+  # everything instead of only affected projects (moon sees no project as affected by them).
+  WORKSPACE_CONFIG_RE: '^(\.moon/|\.prototools|pnpm-lock\.yaml|pnpm-workspace\.yaml|package\.json|\.gitlab-ci\.yml|\.oxlintrc\.json|\.oxfmtrc\.json|\.npmrc|infra/)'
+  MOON_CACHE: "off" # hashes are per-runner; rely on the GitLab caches instead
+  GOMODCACHE: $CI_PROJECT_DIR/.cache/go-mod
+  GOCACHE: $CI_PROJECT_DIR/.cache/go-build
+  GOFLAGS: -buildvcs=false
+  PNPM_HOME: $CI_PROJECT_DIR/.cache/pnpm
+
+.test-cache:
+  cache:
+    - key:
+        files: [pnpm-lock.yaml]
+      paths: [.cache/pnpm, node_modules]
+    - key:
+        files: [apps/CHANGEME_API_APP/go.sum]
+      paths: [.cache/go-mod, .cache/go-build]
+
+# ---------------------------------------------------------------------------
+# Everything that must pass before review starts.
+# ---------------------------------------------------------------------------
+lint-typecheck-build:
   stage: test
   interruptible: true
   extends:
+    - .setup
+    - .test-cache
     - .rules:merge-request
-  script:
-    - echo "Running test..."
   variables:
-    GIT_DEPTH: 1
-    AUTH_TIMEOUT: 10
+    MOON_BASE: $CI_MERGE_REQUEST_DIFF_BASE_SHA # moon --affected compares HEAD against this
+  script:
+    # Only projects touched by the MR (plus their dependents' tasks) — unless a workspace-level
+    # file changed, in which case everything runs. `moon --affected` alone would run nothing then.
+    - |
+      if git diff --name-only "$CI_MERGE_REQUEST_DIFF_BASE_SHA"...HEAD | grep -qE "$WORKSPACE_CONFIG_RE"; then
+        echo "workspace config changed → running all projects"; AFFECTED=""
+      else
+        echo "running affected projects only (base $CI_MERGE_REQUEST_DIFF_BASE_SHA)"; AFFECTED="--affected --downstream deep"
+      fi
+      moon run :lint :typecheck :build $AFFECTED
+    # oxlint runs with --fix; a diff here means someone committed unlinted code.
+    - git diff --exit-code -- . ':(exclude)pnpm-lock.yaml' || { echo "lint --fix changed files; run 'moon run :lint :format' and commit"; exit 1; }
+
+# ---------------------------------------------------------------------------
+# Coverage-gated suites, one job per project so failures are attributable.
+# ---------------------------------------------------------------------------
+test-api:
+  stage: test
+  interruptible: true
+  extends:
+    - .setup
+    - .test-cache
+  needs: [lint-typecheck-build]
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "merge_request_event"
+      changes:
+        - apps/CHANGEME_API_APP/**/*
+        - .moon/**/*
+        - .prototools
+        - .gitlab-ci.yml
+        - infra/**/*
+    - when: never
+  services:
+    - name: docker:27-dind
+      alias: docker
+      command: ["--tls=false"]
+  variables:
+    # testcontainers-go talks to the dind service over TCP; ryuk needs privileged
+    # containers and is unnecessary for short-lived CI jobs.
+    DOCKER_HOST: tcp://docker:2375
+    DOCKER_TLS_CERTDIR: ""
+    TESTCONTAINERS_HOST_OVERRIDE: docker
+    TESTCONTAINERS_RYUK_DISABLED: "true"
+    GOTESTSUM_JUNITFILE: $CI_PROJECT_DIR/apps/CHANGEME_API_APP/build/junit.xml # gotestsum writes JUnit for the MR test tab
+  script:
+    - cp -n apps/CHANGEME_API_APP/.env.example apps/CHANGEME_API_APP/.env
+    - moon run CHANGEME_API_APP:coverage # runs scripts/coverage-gate.sh → exit 1 below any tier floor
+  # GitLab reads the job's coverage % from the gate's "overall" line.
+  coverage: '/^\s*overall\s+(\d+\.\d+)%/'
+  artifacts:
+    when: always
+    expire_in: 1 week
+    paths:
+      - apps/CHANGEME_API_APP/build/coverage.out
+      - apps/CHANGEME_API_APP/build/coverage.html
+    reports:
+      junit: apps/CHANGEME_API_APP/build/junit.xml
+
+.test-frontend:
+  stage: test
+  interruptible: true
+  extends:
+    - .setup
+    - .test-cache
+  needs: [lint-typecheck-build]
+  script:
+    - moon run ${APP}:test-coverage # vitest --coverage; thresholds in vitest.config.ts → exit 1 below floor
+  coverage: '/^\s*Lines\s*:\s*(\d+\.\d+)%/'
+  artifacts:
+    when: always
+    expire_in: 1 week
+    paths:
+      - apps/${APP}/tests-results
+    reports:
+      junit: apps/${APP}/tests-results/junit.xml
+
+# One job per SPA: copy this block and change APP + the changes: list.
+test-web:
+  extends: .test-frontend
+  variables: { APP: CHANGEME_WEB_APP }
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "merge_request_event"
+      changes:
+        - apps/CHANGEME_WEB_APP/**/*
+        - packages/shared-ui/**/*
+        - pnpm-lock.yaml
+        - pnpm-workspace.yaml
+        - package.json
+        - .moon/**/*
+        - .prototools
+        - .gitlab-ci.yml
+        - infra/**/*
+    - when: never


### PR DESCRIPTION
> **Stacked on #153 → #151 → #150.** References the `coverage` / `test-coverage` tasks and helpers those PRs add, so it lands last. Merge order: #150 → #151 → #153 → this.

## Description 📋

### `docsite/content/moonrepo-testing.md`
Was a list of `build`/`start` commands. Now documents how generated projects are tested:
- **The loop** — red → green → refactor, what "failing for the right reason" means, never weaken a test to get green.
- **Which test to write first, per layer** — one table for `go-modular` (domain, service, repository, handler, fx wiring, webhook receiver, third-party client, migration, whole app) and one for `react-app` (logic, component, route via `renderAt`, API call, e2e journey, `shared-ui`). Generalised from a downstream project; no project-specific rows.
- **Fixtures** — recorded, never invented; seeders are the only realistic-data source; redact PII.
- **Coverage** — honest denominator, floors ship at 0, and the **ratchet rule**: floor = measured − 5, only ever raised, history recorded next to the value.
- **Definition of done** — generic checklist.
- **CI** — reproduce a clean checkout locally before pushing task/CI changes (`MOON_CACHE=off`, `git clean -fdX`) and *why*: inferred tasks have no declared outputs, and generated inputs must be produced by a dependency. This is the lesson from a day lost downstream.
- The old smoke-test commands survive under "Template smoke tests".

### `contribution-guidelines.md` §6
The Tests bullet links to the page and carries the clean-checkout advice.

### `templates/gitlab-cicd/test/all.yml`
Replaces the `echo "Running test..."` stub with jobs mirroring the local gates so CI and `moon run …` agree:
- `lint-typecheck-build` — affected projects only (`--affected --downstream deep`), or everything if a workspace-level file changed; fails if `lint --fix` produced a diff.
- `test-api` — Docker-in-Docker for testcontainers (ryuk disabled, host override), `moon run <api>:coverage`, the gate's `overall` line as the job coverage regex, JUnit + coverage artifacts.
- `.test-frontend` job template + one example SPA job — `moon run <spa>:test-coverage`, `Lines` regex, JUnit from `tests-results/junit.xml`.
- Uses the template's existing `.setup` and `.rules:merge-request` anchors; `CHANGEME_API_APP` / `CHANGEME_WEB_APP` placeholders follow the template's `CHANGEME_*` convention.

### `templates/gitlab-cicd/.gitlab/merge_request_templates/Default.md`
The definition-of-done checklist as an MR template (generic: persistence / queue / integration / third-party contract sections).

### Noticed, not changed
`templates/gitlab-cicd/.gitlab-ci.yml` includes `/deploy/pipelines/test/test.yml`, but the file is `test/all.yml` and the template's destination is `infra/[package_name]` (the other includes use `/infra/...`). Looks like pre-existing drift — happy to fix in this PR if you confirm the intended paths.

## Type of change 🤔

- [x] Documentation (a change to documentation)
- [x] Feature (non breaking change which adds functionality) — the gitlab-cicd test jobs

## Submission checklist ✅

- [x] I have performed a self review of my changes
- [x] I have updated the documentation where relevant
- [x] My changes are well written and all ci is passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)