### PR TITLE
feat(docker): moon-ci image with pin-derived tags, used by the gitlab-cicd template

### DIFF
--- a/.github/workflows/ci-image.yaml
+++ b/.github/workflows/ci-image.yaml
@@ -1,0 +1,90 @@
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+
+# Builds and pushes docker.io/01group/moon-ci (docker/ci/Dockerfile).
+# The immutable tag is derived from the toolchain pins so it can never disagree with them:
+#   moon<M>-go<G.major.minor>-node<N.major>-pnpm<P.major>   e.g. moon2.5.3-go1.27-node24-pnpm11
+
+name: CI Image
+
+on:
+    push:
+        branches:
+            - main
+        paths:
+            - 'docker/ci/**'
+            - '.moon/toolchains.yml'
+            - '.moon/workspace.yml'
+            - '.github/workflows/ci-image.yaml'
+    workflow_dispatch:
+
+permissions:
+    contents: read
+
+concurrency:
+    group: ci-image
+    cancel-in-progress: true
+
+defaults:
+    run:
+        shell: bash
+
+jobs:
+    build:
+        runs-on: ubuntu-latest
+        env:
+            IMAGE: docker.io/01group/moon-ci
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v7
+
+            - name: Derive versions from the pins
+              id: pins
+              run: |
+                  set -euo pipefail
+                  # First `version:` under the top-level key `$1` in .moon/toolchains.yml.
+                  pin() { awk -v k="$1" '$0 ~ "^"k":" {f=1; next} f && /^[^[:space:]#]/ {f=0} f && /^[[:space:]]+version:/ {v=$2; gsub(/[^0-9.]/, "", v); print v; exit}' .moon/toolchains.yml; }
+                  MOON=$(sed -nE "s/^versionConstraint:[[:space:]]*'?>=?([0-9.]+).*/\1/p" .moon/workspace.yml)
+                  PROTO=$(pin proto); GO=$(pin go); NODE=$(pin node); PNPM=$(pin pnpm)
+                  for v in MOON PROTO GO NODE PNPM; do [ -n "${!v}" ] || { echo "could not read $v pin"; exit 1; }; done
+                  # Go image tags need major.minor.patch; the toolchains file may pin major.minor.
+                  case "$GO" in *.*.*) ;; *) GO="$GO.0" ;; esac
+                  TAG="moon${MOON}-go${GO%.*}-node${NODE%%.*}-pnpm${PNPM%%.*}"
+                  echo "moon=$MOON proto=$PROTO go=$GO node=$NODE pnpm=$PNPM → $TAG"
+                  {
+                    echo "moon=$MOON"; echo "proto=$PROTO"; echo "go=$GO"
+                    echo "node=${NODE%%.*}"; echo "pnpm=$PNPM"; echo "tag=$TAG"
+                  } >> "$GITHUB_OUTPUT"
+
+            - name: Set up Docker Buildx
+              uses: docker/setup-buildx-action@v3
+
+            - name: Login to Docker Hub
+              uses: docker/login-action@v3
+              with:
+                  username: ${{ secrets.DOCKERHUB_USERNAME }}
+                  password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+            - name: Build and push
+              uses: docker/build-push-action@v6
+              with:
+                  context: docker/ci
+                  file: docker/ci/Dockerfile
+                  platforms: linux/amd64
+                  push: true
+                  provenance: false
+                  build-args: |
+                      MOON_VERSION=${{ steps.pins.outputs.moon }}
+                      PROTO_VERSION=${{ steps.pins.outputs.proto }}
+                      GO_VERSION=${{ steps.pins.outputs.go }}
+                      NODE_VERSION=${{ steps.pins.outputs.node }}
+                      PNPM_VERSION=${{ steps.pins.outputs.pnpm }}
+                  tags: |
+                      ${{ env.IMAGE }}:${{ steps.pins.outputs.tag }}
+                      ${{ env.IMAGE }}:latest
+                  cache-from: type=gha
+                  cache-to: type=gha,mode=max
+
+            - name: Smoke test
+              run: |
+                  docker run --rm ${{ env.IMAGE }}:${{ steps.pins.outputs.tag }} \
+                    bash -lc 'moon --version && go version && node --version && pnpm --version && swag --version && gotestsum --version'

--- a/docker/ci/Dockerfile
+++ b/docker/ci/Dockerfile
@@ -1,0 +1,73 @@
+# syntax=docker/dockerfile:1.7
+# CI image for moon + pnpm monorepos (Go + Node). Public: docker.io/01group/moon-ci
+#
+# Contains exactly the toolchain this monorepo pins in .moon/toolchains.yml (and
+# .moon/workspace.yml for moon), so a pipeline job skips apt + proto + tool downloads
+# (~3–4 min/job). Nothing project-specific is baked in: sources, node_modules and the Go
+# module cache come from the checkout and the CI cache.
+#
+# Size matters more than anything else here: runners cold-pull it once per tag. Node comes
+# from the base image (not a second copy via proto) and the Go CLI tools are built in a
+# throwaway stage so only their binaries land in the final image.
+#
+# Built and pushed by .github/workflows/ci-image.yaml on every push to main that touches
+# docker/ci/**; the tag is derived from the pins so it cannot disagree with them:
+#   moon<M>-go<G.major.minor>-node<N.major>-pnpm<P.major>   e.g. moon2.5.3-go1.27-node24-pnpm11
+# Manual build (amd64):
+#   docker buildx build --platform linux/amd64 -f docker/ci/Dockerfile \
+#     -t 01group/moon-ci:moon2.5.3-go1.27-node24-pnpm11 -t 01group/moon-ci:latest --push docker/ci
+# Bump a version → bump the pin, the workflow rebuilds and pushes the new tag; pin it in CI.
+
+ARG NODE_VERSION=24
+ARG GO_VERSION=1.27.0
+
+# ---- stage 1: build Go CLI tools, keep only the binaries -------------------------------
+FROM golang:${GO_VERSION}-trixie AS gotools
+ARG SWAG_VERSION=v1.16.6
+ARG GOTESTSUM_VERSION=v1.13.0
+ARG MOCKERY_VERSION=v3.5.1
+ENV GOFLAGS=-trimpath CGO_ENABLED=0 GOBIN=/out
+RUN go install "github.com/swaggo/swag/cmd/swag@${SWAG_VERSION}" \
+ && go install "gotest.tools/gotestsum@${GOTESTSUM_VERSION}" \
+ && go install "github.com/vektra/mockery/v3@${MOCKERY_VERSION}"
+
+# ---- stage 2: the CI image ---------------------------------------------------------------
+FROM node:${NODE_VERSION}-trixie-slim
+ARG GO_VERSION
+ARG PROTO_VERSION=0.61.1
+ARG MOON_VERSION=2.5.3
+ARG PNPM_VERSION=11.23.0
+
+# proto installs moon and Go under PROTO_HOME (outside $HOME so any uid works; runners use root).
+ENV PROTO_HOME=/opt/proto \
+    GOPATH=/opt/go \
+    GOTOOLCHAIN=local \
+    GOFLAGS=-buildvcs=false \
+    COREPACK_ENABLE_DOWNLOAD_PROMPT=0 \
+    MOON_ALLOW_ROOT=1 \
+    CI=true
+ENV PATH="${PROTO_HOME}/shims:${PROTO_HOME}/bin:${GOPATH}/bin:/usr/local/bin:${PATH}"
+
+RUN apt-get update -qq \
+ && apt-get install -y -qq --no-install-recommends ca-certificates curl git jq unzip xz-utils openssh-client \
+ && rm -rf /var/lib/apt/lists/*
+
+# pnpm via corepack on the base image's Node — no second Node install.
+RUN corepack enable && corepack prepare "pnpm@${PNPM_VERSION}" --activate && pnpm --version
+
+# proto → moon + Go only. `proto use` in a project still works: node/pnpm resolve to these.
+RUN curl -fsSL https://moonrepo.dev/install/proto.sh | bash -s -- "${PROTO_VERSION}" --yes --no-profile \
+ && proto install moon "${MOON_VERSION}" --pin=global \
+ && proto install go "${GO_VERSION}" --pin=global \
+ && rm -rf "${PROTO_HOME}/temp" "${PROTO_HOME}/tools/go/${GO_VERSION}/test" "${PROTO_HOME}/tools/go/${GO_VERSION}/doc" \
+ && moon --version && go version
+
+COPY --from=gotools /out/swag /out/gotestsum /out/mockery /usr/local/bin/
+RUN swag --version && gotestsum --version && mockery version
+
+# Login shells (`bash -l`, interactive `docker run`) source /etc/profile, which resets PATH.
+RUN printf 'export PROTO_HOME=%s GOPATH=%s\nexport PATH="%s/shims:%s/bin:%s/bin:$PATH"\n' \
+      "${PROTO_HOME}" "${GOPATH}" "${PROTO_HOME}" "${PROTO_HOME}" "${GOPATH}" > /etc/profile.d/moon-ci.sh
+
+WORKDIR /workspace
+CMD ["bash"]

--- a/docker/ci/README.md
+++ b/docker/ci/README.md
@@ -1,0 +1,42 @@
+# `01group/moon-ci` — CI image for moon + pnpm monorepos
+
+Public image on Docker Hub with the toolchain this monorepo pins: proto → moon, Go, Node,
+pnpm, plus `swag`, `gotestsum`, `mockery`. Pipelines skip the 3–4 minute apt/proto/download
+dance per job. Nothing project-specific is baked in.
+
+| Tag                              | Meaning                                                            |
+| -------------------------------- | ------------------------------------------------------------------ |
+| `moon2.5.3-go1.27-node24-pnpm11` | immutable — what a project's CI pins                               |
+| `latest`                         | newest build from `main`                                           |
+
+The immutable tag is **derived from the pins** (`.moon/workspace.yml` `versionConstraint`,
+`.moon/toolchains.yml` `go` / `node` / `pnpm`) by `.github/workflows/ci-image.yaml`, so the tag
+can never disagree with what the repo actually uses.
+
+## Rebuild
+
+Automatic: every push to `main` that touches `docker/ci/**`, `.moon/toolchains.yml` or
+`.moon/workspace.yml` builds `linux/amd64` and pushes the derived tag + `latest`. Requires the
+`DOCKERHUB_USERNAME` / `DOCKERHUB_TOKEN` organisation secrets with push rights to `01group`.
+
+Manual:
+
+```sh
+docker login                        # as 01group
+docker buildx build --platform linux/amd64 -f docker/ci/Dockerfile \
+  --build-arg GO_VERSION=1.27.0 --build-arg MOON_VERSION=2.5.3 --build-arg PNPM_VERSION=11.23.0 \
+  -t 01group/moon-ci:moon2.5.3-go1.27-node24-pnpm11 -t 01group/moon-ci:latest \
+  --push docker/ci
+```
+
+Verify a tag before pinning it:
+
+```sh
+docker run --rm -it 01group/moon-ci:<tag> bash -lc 'moon --version; go version; node --version; pnpm --version; swag --version'
+```
+
+## Using it
+
+`templates/gitlab-cicd/dependencies/base.yml` sets `.setup.image` to the immutable tag. When you
+bump a toolchain pin, bump that tag in the same change; the `.gitlab-ci.yml` of every generated
+project inherits it on the next `moon generate`.

--- a/docsite/content/configuration.md
+++ b/docsite/content/configuration.md
@@ -36,3 +36,18 @@ We use `.env` files to manage environment-specific configurations.
 ## Package Scripts
 
 While moonrepo is the primary task runner, we also use `package.json` scripts for standard Node.js workflows. Moon is configured to infer tasks from these scripts automatically where appropriate.
+
+## CI Image
+
+`docker/ci/Dockerfile` builds `docker.io/01group/moon-ci`, a public image with the toolchain
+this monorepo pins (proto → moon, Go, Node, pnpm) plus `swag`, `gotestsum` and `mockery`.
+Pipelines that use it skip the apt/proto/download setup (3–4 minutes per job).
+
+- The immutable tag is derived from the pins — `moon<M>-go<G>-node<N>-pnpm<P>`, e.g.
+  `moon2.5.3-go1.27-node24-pnpm11` — by `.github/workflows/ci-image.yaml`, which rebuilds on
+  every push to `main` touching `docker/ci/**` or the toolchain files.
+- The `gitlab-cicd` template's `.setup` job uses it. When you bump a pin in
+  `.moon/toolchains.yml`, bump the tag in `templates/gitlab-cicd/dependencies/base.yml` in the
+  same change.
+- See `docker/ci/README.md` for manual builds and how to verify a tag.
+

--- a/templates/gitlab-cicd/dependencies/base.yml
+++ b/templates/gitlab-cicd/dependencies/base.yml
@@ -1,11 +1,11 @@
+# The image (docker/ci/Dockerfile in zero-one-group/monorepo, public on Docker Hub) already
+# carries proto → moon / Go / Node / pnpm at the monorepo's pinned versions plus swag, gotestsum
+# and mockery, so a job only installs workspace dependencies. Bump the tag together with any
+# change to .moon/toolchains.yml; the tag encodes the pins (moon<M>-go<G>-node<N>-pnpm<P>).
 .setup:
-  image: node:24-trixie-slim
+  image: docker.io/01group/moon-ci:moon2.5.3-go1.27-node24-pnpm11
   before_script:
-    - apt-get update && apt-get install curl git -y
-    - bash <(curl -fsSL https://moonrepo.dev/install/moon.sh)
-    - export PATH="$HOME/.moon/bin:$PATH"
-    - corepack enable
-    - corepack prepare pnpm@latest-10 --activate
+    - moon --version && node --version && pnpm --version && go version
     # Clean reinstall to avoid stale/orphaned nested node_modules dirs left behind by
     # `node-linker: hoisted` after dependency version bumps. Such orphans shadow the
     # correct versions during rollup bundling and break builds (e.g. strapi admin panel).


### PR DESCRIPTION
> **Stacked on #154 → #153 → #151 → #150.** Content-wise independent; #154's docs reference the image, so it sits last in the stack. Merge order: #150 → #151 → #153 → #154 → this.
>
> **Needs a maintainer decision:** the Docker Hub namespace. `01group/moon-ci` is already public with the `moon2.5.3-go1.27-node24-pnpm11` tag (pushed manually from a downstream project), so everything here works as-is. If you'd rather cut tags from this repo, the workflow does that once `DOCKERHUB_USERNAME` / `DOCKERHUB_TOKEN` org secrets exist. If you prefer a different namespace, it's one string in three files.

## Description 📋

### `docker/ci/Dockerfile` + `docker/ci/README.md`
`node:<N>-trixie-slim` + pnpm via corepack + proto → moon and Go, with `swag` / `gotestsum` / `mockery` built in a throwaway stage so only the binaries land in the image. Nothing project-specific is baked in. A pipeline job skips the apt/proto/download setup (~3–4 min per job). Lives under `docker/` next to `_stacks_` and `postgres` — it's monorepo infrastructure, not a generated template. `docker buildx build --check` passes.

### `.github/workflows/ci-image.yaml`
Builds `linux/amd64` and pushes on every push to `main` touching `docker/ci/**`, `.moon/toolchains.yml` or `.moon/workspace.yml` (+ `workflow_dispatch`). **The immutable tag is derived from the pins** — `versionConstraint` in `.moon/workspace.yml` for moon, `.moon/toolchains.yml` for proto/go/node/pnpm — as `moon<M>-go<G.major.minor>-node<N.major>-pnpm<P.major>`, and the same values feed the build args, so the tag can never disagree with what the repo uses. Verified locally: today's pins → `moon2.5.3-go1.27-node24-pnpm11`, identical to the tag already on Hub. Ends with a smoke test of the pushed tag. Uses `docker/build-push-action@v6` with GHA layer cache.

### `templates/gitlab-cicd/dependencies/base.yml`
`.setup` uses the image instead of installing `curl`/`git`, `moon.sh` and corepack on `node:24-trixie-slim` at job time. Worth noting: the old block ran `corepack prepare pnpm@latest-10`, which **contradicts the pnpm 11.x pin** in `.moon/toolchains.yml` — generated projects were testing with a different pnpm than they develop with.

### `docsite/content/configuration.md`
New "CI Image" section: what it is, how the tag is derived, bump the tag together with a pin change.

## Type of change 🤔

- [x] Feature (non breaking change which adds functionality)

## Submission checklist ✅

- [x] I have performed a self review of my changes
- [x] I have updated the documentation where relevant
- [x] My changes are well written and all ci is passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)