### PR TITLE
chore(vpn): update README.md

### DIFF
--- a/templates/ansible/roles/vpn/README.md
+++ b/templates/ansible/roles/vpn/README.md
@@ -22,6 +22,66 @@ Run the following command to execute the playbook with the VPN setup tag:
 ansible-playbook -i inventory.ini initial-setup.yml --tags vpn
 ```
 
+## 📊 Capacity Planning
+
+How many users you can create, and how many of them can stay connected at the
+same time, are two different limits:
+
+- **Concurrent clients** is bound by the Pritunl node (CPU and network).
+- **Total users** is bound by MongoDB (memory).
+
+Most of the numbers below come from the official
+[Pritunl scaling guide](https://docs.pritunl.com/kb/vpn/system/scaling);
+`t3.micro` and `t3.small` are our own estimates.
+
+### Concurrent clients per node
+
+| Size class | AWS         | Google Cloud   | Resources                   | Max concurrent clients |
+| ---------- | ----------- | -------------- | --------------------------- | ---------------------- |
+| micro      | `t3.micro`  | `e2-micro`     | 2 vCPU (burstable), low net | ~60 (estimate)¹        |
+| small      | `t3.small`  | `e2-small`     | 2 vCPU (burstable), low net | ~125 (estimate)¹       |
+| medium     | `t3.medium` | `n1-highcpu-2` | 2 vCPU, low to moderate net | 250                    |
+| large      | `c5.large`  | `n1-highcpu-4` | 2–4 vCPU, up to 10 Gigabit  | 1000                   |
+| xlarge     | `c5.xlarge` | `n1-highcpu-8` | 4–8 vCPU, up to 10 Gigabit  | 2000                   |
+
+Pritunl doesn't list anything below `t3.medium`, so these two are scaled down
+from the documented 250 — worth checking under real load before you rely on
+them. Both sizes suit dev environments more than production: their CPU is
+burstable, so heavy OpenVPN traffic tends to eat the credit balance and slow
+things down well before you hit the client count.
+
+The GCP column is matched to the AWS row by max clients, not by vCPU count.
+"Max clients" means concurrent connections, not the number of user accounts.
+
+### Total users (MongoDB)
+
+| AWS         | Google Cloud   | Memory     | Max users |
+| ----------- | -------------- | ---------- | --------- |
+| `r3.large`  | `n1-highmem-2` | 13–15 GB   | 20000     |
+| `r3.xlarge` | `n1-highmem-4` | 26–30.5 GB | 40000     |
+
+### What this means for this setup
+
+This role keeps everything on one VM. The image bundles Pritunl, OpenVPN and
+MongoDB in a single container, with data living in `./pritunl` and `./mongodb`
+next to `vpn.yml` — see [`files/vpn.yml`](files/vpn.yml). There's no separate
+database host and no second node.
+
+So treat the client table as a ceiling rather than a target: the database, the
+web console and OpenVPN all share the same vCPUs, memory and NIC. Pick a size
+with some headroom over the client count you actually expect.
+
+The MongoDB table assumes a dedicated database host, so it doesn't map onto this
+setup directly. Here the user count is rarely what you run out of first — on a
+single VM you'll feel the concurrent-client limit long before the database
+becomes the bottleneck.
+
+Pritunl's own answer for larger deployments is a separate MongoDB, several nodes
+behind DNS names, and a low **Max Clients** per server so clients spill over to
+another node instead of piling onto one. That's all worth reading if you outgrow
+this, but none of it is what this role sets up — it would mean reworking
+`vpn.yml` and running MongoDB somewhere else.
+
 ## 📝 Notes
 
 The compose file must **not** pin the container DNS to `127.0.0.1`: nothing


### PR DESCRIPTION
## Description 📋

Adds a **Capacity Planning** section to the `vpn` role README: how many users
a Pritunl deployment can hold, and how many can be connected at the same time,
per instance size from `micro` to `xlarge`.

Covers two separate limits — concurrent clients (CPU/network) and total users
(MongoDB memory) — plus a short note on reading both against the single-VM
setup this role creates

## What's included

- **Concurrent clients per node** — `micro` through `xlarge`, with AWS and GCP
  instance types side by side and the resources behind each number.
- **Total users (MongoDB)** — the documented user ceilings per memory size.
- **What this means for this setup** — how to read both tables against the
  single-VM deployment this role actually creates.

Please tick any that are relevant to this PR and remove any that aren't.

- [ ] Bugfix (non breaking change which resolve an issue)
- [ ] Feature (non breaking change which adds functionality)
- [ ] Breaking Change (a change which would cause existing functionality to not work as expected)
- [x] Documentation (a change to documentation)

## Submission checklist ✅

- [x] I have performed a self review of my changes
- [x] I have updated the documentation where relevant
- [x] My changes are well written and all ci is passing
